### PR TITLE
Remove UdonSharp Dependency since it's redundant now.

### DIFF
--- a/Packages/com.vrcbilliards.vrcbce/package.json
+++ b/Packages/com.vrcbilliards.vrcbce/package.json
@@ -3,13 +3,12 @@
   "version": "1.6.0",
   "displayName": "VRCBilliards",
   "description": "The definitive edition of VRChat's most popular game prefab!\nReliable, extensible, *and* heavily performant (even on Quest!)",
-  "unity": "2019.4",
   "author": {
     "name": "VRCBilliards",
     "url": "https://github.com/VRCBilliards"
   },
   "vpmDependencies": {
-    "com.vrchat.udonsharp": "1.x.x"
+    "com.vrchat.worlds": "^3.2.0"
   },
   "samples": [
     {


### PR DESCRIPTION
In case it wasn't known yet, UdonSharp has been fully integrated into the Worlds SDK. Yes, you heard that right. No more separate UdonSharp Package needed.

This Pull Request was still made because some versions of Creator Companion will still import UdonSharp when it's not necessary, since it's already in SDK 3.4.0. Therefore, the dependency has been replaced.

If there are other things in this repository that needs changes to accommodate the changed UdonSharp location (which is now `./Packages/com.vrchat.worlds/Integrations/UdonSharp`), I highly recommend you make those changes ASAP.

Thanks,
BluWizard